### PR TITLE
When the app gets into the background, iOS eco system provides around…

### DIFF
--- a/ShipBookSDK/Classes/Appenders/SBCloudAppender.swift
+++ b/ShipBookSDK/Classes/Appenders/SBCloudAppender.swift
@@ -31,6 +31,7 @@ class SBCloudAppender: BaseAppender{
   private var backgroundObserver: NSObjectProtocol? = nil
   private var connectedObserver: NSObjectProtocol? = nil
   private var userChangeObserver: NSObjectProtocol? = nil
+  private var backgroundTaskID: UIBackgroundTaskIdentifier = .invalid
   
   private var uploadingSavedData = false
   var hasLog = false
@@ -58,6 +59,16 @@ class SBCloudAppender: BaseAppender{
         DispatchQueue.shipBook.async {
           InnerLog.d("I'm out of focus!")
           // it will close soon so better send the information
+          self?.backgroundTaskID = UIApplication.shared.beginBackgroundTask (withName: "Finish Network Tasks") {
+              // End the task if time expires.
+              guard let taskId = self?.backgroundTaskID else {
+                  return
+              }
+              UIApplication.shared.endBackgroundTask(taskId)
+              self?.backgroundTaskID = .invalid
+          }
+                
+          // Send the data synchronously.
           self?.send()
         }
     }
@@ -69,6 +80,16 @@ class SBCloudAppender: BaseAppender{
         DispatchQueue.shipBook.async {
           InnerLog.d("I'm out of focus!")
           // it will close soon so better send the information
+          self?.backgroundTaskID = UIApplication.shared.beginBackgroundTask (withName: "Finish Network Tasks") {
+              // End the task if time expires.
+              guard let taskId = self?.backgroundTaskID else {
+                  return
+              }
+              UIApplication.shared.endBackgroundTask(taskId)
+              self?.backgroundTaskID = .invalid
+          }
+                
+          // Send the data synchronously.
           self?.send()
         }
     }


### PR DESCRIPTION
… 5 seconds to perform any activities we need.

But it seems like when the app opens and is closed or control is transferred to another app with a second then the logs are not making it to the Shipbook server.
So using the UIApplication.shared.beginBackgroundTask provides us with some extra time to push the logs.
It works fine on our prod app. Please test it for Swift < 4.2.

https://developer.apple.com/documentation/uikit/app_and_environment/scenes/preparing_your_ui_to_run_in_the_background/extending_your_app_s_background_execution_time